### PR TITLE
Fixed Wysiwyg reversing text

### DIFF
--- a/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/index.js
+++ b/packages/strapi-plugin-content-manager/admin/src/components/Wysiwyg/index.js
@@ -136,6 +136,11 @@ class Wysiwyg extends React.Component {
     // Since we need to perform some operations in the reducer the loading phase stops before all the operations
     // are computed which in some case causes the inputs component to be initialised with a null value.
     if (!prevProps.value && this.props.value) {
+      // This is also called if the first thing you add in the editor is
+      // a markdown formatting block (b, i, u, etc.) which results in
+      // the selection being pushed to the end after the first character is added.
+      // Basically, setInitialValue is always called whenever
+      // you start typing in an empty editor (even after the initial load)
       this.setInitialValue(this.props);
     }
   }
@@ -192,24 +197,31 @@ class Wysiwyg extends React.Component {
       textWithEntity,
       'insert-character'
     );
-    // Update the parent reducer
-    this.sendData(newEditorState);
-    // Don't handle selection : the user has selected some text to be changed with the appropriate markdown
-    if (selectedText !== '') {
-      return this.setState(
-        {
-          editorState: newEditorState,
-        },
-        () => {
-          this.focus();
-        }
-      );
+    
+    if (selectedText.length === 0) {
+      this.setState({
+        // Highlight the text if the selection was empty
+        editorState: EditorState.forceSelection(newEditorState, updatedSelection),
+      }, () => {
+        this.focus();
+        // Update the parent reducer
+        this.sendData(newEditorState);
+      });
+      return;
     }
 
-    return this.setState({
-      // Highlight the text if the selection wad empty
-      editorState: EditorState.forceSelection(newEditorState, updatedSelection),
-    });
+    // Don't handle selection: the user has selected some text to be changed with the appropriate markdown
+    this.setState(
+      {
+        editorState: newEditorState,
+      },
+      () => {
+        this.focus();
+        // Update the parent reducer
+        this.sendData(newEditorState);
+      }
+    );
+    return;
   };
 
   /**


### PR DESCRIPTION
After adding a MD formatting block (b, i, u, etc.) the text would be reversed. This fixes that issue as well as automatically selecting the placeholder text when no selection is being made.

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch)
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/master/CONTRIBUTING.md
-->

### What does it do?

Updated the `addContent` method. Called .focus() every time the editor state is updated.

### Why is it needed?

The text was reversed after adding a formatting block.

### Related issue(s)/PR(s)

#7991
